### PR TITLE
Fix PSCP typo

### DIFF
--- a/episodes/05-writing-scripts.md
+++ b/episodes/05-writing-scripts.md
@@ -391,7 +391,7 @@ to upload data to your virtual machine.
 
 ::::::::::::::: spoiler
 
-### PCSP
+### PSCP
 
 If you're using a Windows PC without Git Bash, we recommend you use the *PSCP* program.
 This program is from the same suite of tools as the PuTTY program we have been using to connect.


### PR DESCRIPTION
## Summary
- fix PSCP heading typo in Windows transfer instructions

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684041c66918832a9190d2dccc2dc9b5